### PR TITLE
Fixed Imports 

### DIFF
--- a/stock_volatility.py
+++ b/stock_volatility.py
@@ -1,10 +1,11 @@
 import numpy as np
 import pandas as pd
 import pandas_datareader.data as pdr
-import fix_yahoo_finance as yf
+import yfinance as yf #Module name changed
 import arch
 import matplotlib.pyplot as plt
 from statsmodels.graphics.tsaplots import plot_acf
+from arch.__future__ import reindexing #Surpress Warning Due to dependency Changes
 yf.pdr_override()
 
 


### PR DESCRIPTION
fix_yahoo_finance changed to yfinance 

Also fixed Issues related to dependecy in reindexing in Arch 
Specifically

[The default for reindex is True. After September 2021 this will change to
False. Set reindex to True or False to silence this message. Alternatively,
you can use the import comment

from arch.__future__ import reindexing

to globally set reindex to True and silence this warning.]